### PR TITLE
fix for #116 - preparing for debug() use in calcDCconfig() and used functions

### DIFF
--- a/calcDCConfig.js
+++ b/calcDCConfig.js
@@ -52,21 +52,21 @@ const calcDCConfig = function (generalValuesLocal, workloadsArrayLocal, sizingCo
             //checkForMisconfigReplicaInDC(generalValuesLocal, workloadsArrayLocal, sizingConstraints, dcConfigArrayLocal, dcItem)
             dcConfigCorrectNumberOfServersForiSCSI(generalValuesLocal, workloadsArrayLocal, sizingConstraints, dcConfigArrayLocal, dcItem)
             // calculate the depending number of media as per preliminary number of servers
-            dcConfigCalcPreliminaryMediaPerServer(dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, dcConfigArrayLocal[dcItem].numberOfServersNeededAllInstances)
-            dcConfigNumberOfCoresNeededInitial(sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
-            dcConfigMemNeededInitial(sizingConstraints, dcConfigArrayLocal, dcItem)
-            dcConfigCheckResourceConstraints(dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
+            dcConfigCalcPreliminaryMediaPerServer(generalValuesLocal, dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, dcConfigArrayLocal[dcItem].numberOfServersNeededAllInstances)
+            dcConfigNumberOfCoresNeededInitial(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
+            dcConfigMemNeededInitial(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, dcItem)
+            dcConfigCheckResourceConstraints(generalValuesLocal, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
             dcConfigMinNumberOfServersNeededWithReducedNumberOfRolesPerServer(generalValuesLocal, workloadsArrayLocal, sizingConstraints, dcConfigArrayLocal, dcItem)
             dcConfigAdjustNumberOfServers(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
             // recalculate the depending number of media as per corrected number of servers
-            dcConfigCalcPreliminaryMediaPerServer(dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis)
-            dcConfigFinalNumberOfCoresPerServer(sizingConstraints, dcConfigArrayLocal, actualChassisID,dcItem)
-            dcConfigFinalMemoryPerServer(sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem)
-            dcConfigFinalSSDPerServer(dcConfigArrayLocal, actualChassisID, dcItem)
-            dcConfigFinalHDDPerServer(dcConfigArrayLocal, actualChassisID, dcItem)
-            dcConfigFinalNVMePerServer(dcConfigArrayLocal,actualChassisID, dcItem, chassisArrayLocal)
-            dcConfigFinalPublicNetwork(sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
-            dcConfigFinalClusterNetwork(sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
+            dcConfigCalcPreliminaryMediaPerServer(generalValuesLocal, dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis)
+            dcConfigFinalNumberOfCoresPerServer(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, actualChassisID,dcItem)
+            dcConfigFinalMemoryPerServer(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem)
+            dcConfigFinalSSDPerServer(generalValuesLocal, dcConfigArrayLocal, actualChassisID, dcItem)
+            dcConfigFinalHDDPerServer(generalValuesLocal, dcConfigArrayLocal, actualChassisID, dcItem)
+            dcConfigFinalNVMePerServer(generalValuesLocal, dcConfigArrayLocal,actualChassisID, dcItem, chassisArrayLocal)
+            dcConfigFinalPublicNetwork(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
+            dcConfigFinalClusterNetwork(generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem)
           }
         }
       }

--- a/dccalc/dcConfigCalcPreliminaryMediaPerServer.js
+++ b/dccalc/dcConfigCalcPreliminaryMediaPerServer.js
@@ -1,5 +1,5 @@
 import displayMsg from "../common/displayMsg.js"
-const dcConfigCalcPreliminaryMediaPerServer = function (dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, numberOfServersNeeded) {
+const dcConfigCalcPreliminaryMediaPerServer = function (generalValuesLocal, dcConfigArrayLocal, dcItem, chassisArrayLocal, actualChassisID, numberOfServersNeeded) {
   // Calculate preliminary number of media per server to avoid constantly calculating something that might be not that obvious at the time of use
   
   if (chassisArrayLocal[actualChassisID].sizeHDD1 > 0) {

--- a/dccalc/dcConfigCheckResourceConstraints.js
+++ b/dccalc/dcConfigCheckResourceConstraints.js
@@ -1,5 +1,5 @@
 // Trying to implement X41
-const dcConfigCheckResourceConstraints = function (dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
+const dcConfigCheckResourceConstraints = function (generalValuesLocal, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
 
   // check if the provided resources by selected chassis would match the required resources for all media and roles
   console.log(`dcConfigCheckResourceConstraints() 5: [chassisID=${actualChassisID},dcItem=${dcItem}] dcConfigArrayLocal[dcItem].prelimPerServerNumberOfCoresNeeded=${dcConfigArrayLocal[dcItem].prelimPerServerNumberOfCoresNeeded}; dcConfigArrayLocal[dcItem].maxCpuSockets*chassisArrayLocal[actualChassisID].maxCpuCores=${chassisArrayLocal[actualChassisID].maxCpuSockets}*${chassisArrayLocal[actualChassisID].maxCpuCores};`)

--- a/dccalc/dcConfigFinalClusterNetwork.js
+++ b/dccalc/dcConfigFinalClusterNetwork.js
@@ -1,5 +1,5 @@
 // Trying to implement AG42 - cluster network
-const dcConfigFinalClusterNetwork   = function (sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalClusterNetwork   = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
   // = if($Y41>0
   //     ,
   //        if ( Isnumber(Cover!$N$8)

--- a/dccalc/dcConfigFinalHDDPerServer.js
+++ b/dccalc/dcConfigFinalHDDPerServer.js
@@ -1,5 +1,5 @@
 // trying to implement AD41
-const dcConfigFinalHDDPerServer   = function (dcConfigArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalHDDPerServer   = function (generalValuesLocal, dcConfigArrayLocal, actualChassisID, dcItem) {
   if (dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis > 0) {
     dcConfigArrayLocal[dcItem].resultingNumberOfHDD = Math.ceil(dcConfigArrayLocal[dcItem].numberOfHDDNeeded / dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis)
   }

--- a/dccalc/dcConfigFinalMemoryPerServer.js
+++ b/dccalc/dcConfigFinalMemoryPerServer.js
@@ -1,5 +1,5 @@
 // trying to implement AA41
-const dcConfigFinalMemoryPerServer   = function (sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalMemoryPerServer   = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem) {
   // =if($Y41>0
   //    ,
   //      roundup($J41/$Y41,0) * $G$6

--- a/dccalc/dcConfigFinalNVMePerServer.js
+++ b/dccalc/dcConfigFinalNVMePerServer.js
@@ -1,7 +1,7 @@
 
 
 // trying to implement AB41, AE41, AF41, etc.
-const dcConfigFinalNVMePerServer   = function (dcConfigArrayLocal, actualChassisID, dcItem, chassisArrayLocal) {
+const dcConfigFinalNVMePerServer   = function (generalValuesLocal, dcConfigArrayLocal, actualChassisID, dcItem, chassisArrayLocal) {
   if (dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis > 0) {
     dcConfigArrayLocal[dcItem].resultingNumberOfNVMe1 = dcConfigArrayLocal[dcItem].prelimPerServerNumberOfNVMe1NeededWithoutDedicatedWAL + dcConfigArrayLocal[dcItem].prelimPerServerNumberOfNVMe1NeededWithDedicatedWAL
     dcConfigArrayLocal[dcItem].resultingNumberOfNVMe2 = dcConfigArrayLocal[dcItem].prelimPerServerNumberOfNVMe2Needed

--- a/dccalc/dcConfigFinalNumberOfCoresPerServer.js
+++ b/dccalc/dcConfigFinalNumberOfCoresPerServer.js
@@ -1,6 +1,6 @@
 // trying to implement Z41
 /// TODO - total rewrite needed for the changed N41 vs NVMe2, and all other NVMe
-const dcConfigFinalNumberOfCoresPerServer   = function (sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalNumberOfCoresPerServer   = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, actualChassisID, dcItem) {
   // Determine the final number of cores per server needed for configuration:
   // =if($Y41>0,roundup($J41/$Y41,0)*$G$5 + roundup($J42/$Y41,0)*$J$5 + if(Cover!$U$8="x",$G$3,0) + roundup($N41/$Y41,0)*$AH$5 + $AR$5 + if(C41>0,if(roundup(($Y41-$S41-$E41)/C41,0)<1,$AR$4,0),0),0)
   // =if($Y41>0

--- a/dccalc/dcConfigFinalPublicNetwork.js
+++ b/dccalc/dcConfigFinalPublicNetwork.js
@@ -1,5 +1,5 @@
 // Trying to implement AG41 -- public network
-const dcConfigFinalPublicNetwork   = function (sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalPublicNetwork   = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
   // = if($Y41>0
   //     ,if ( Isnumber(Cover!$N$8)
   //         , if ( 

--- a/dccalc/dcConfigFinalSSDPerServer.js
+++ b/dccalc/dcConfigFinalSSDPerServer.js
@@ -4,7 +4,7 @@
  * Note that SSD4 generally doesn't need additional resources since this is already accounted for with the resources for the HDD coreing it. Expecting no change for futher code changes.
  */
 
-const dcConfigFinalSSDPerServer   = function (dcConfigArrayLocal, actualChassisID, dcItem) {
+const dcConfigFinalSSDPerServer   = function (generalValuesLocal, dcConfigArrayLocal, actualChassisID, dcItem) {
 console.log(`dcConfigFinalSSDPerServer() 4: dcConfigArrayLocal[dcItem=${dcItem}].resultingNumberOfServersAsPerChassis=${dcConfigArrayLocal[dcItem].resultingNumberOfServersAsPerChassis} > 0 ?`)
 // RGW caching uses NVMe2 now
 

--- a/dccalc/dcConfigMemNeededInitial.js
+++ b/dccalc/dcConfigMemNeededInitial.js
@@ -1,5 +1,5 @@
 // Trying to implement W41
-const dcConfigMemNeededInitial = function (sizingConstraints, dcConfigArrayLocal, dcItem) {
+const dcConfigMemNeededInitial = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, dcItem) {
   // =if($T41>0,roundup($J41/$T41,0)*$G$6+roundup($J42/$T41,0)*$J$6+roundup($N41/T41,0)*$AH$6+$AR$6+if(C41>0,if(roundup(($T41-$S41-$E41)/C41,0)<1,$AR$7,0),0),0)
   if (dcConfigArrayLocal[dcItem].numberOfServersNeededAllInstances > 0) {
     let localMemPerAdditionalRole = 0

--- a/dccalc/dcConfigNumberOfCoresNeededInitial.js
+++ b/dccalc/dcConfigNumberOfCoresNeededInitial.js
@@ -1,6 +1,6 @@
 // Trying to implement V41 including all other NVMe as well
 // =if ( $T41 >0,roundup($J41/$T41,0)*$G$5+roundup($J42/$T41,0)*$J$5+if(Cover!$U$8="x",$G$3,0)+roundup($N41/$T41,0)*$AH$5+$AR$5+if(C41>0,if(roundup(($T41-$S41-$E41)/C41,0)<1,$AR$4,0),0),0)
-const dcConfigNumberOfCoresNeededInitial = function (sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
+const dcConfigNumberOfCoresNeededInitial = function (generalValuesLocal, sizingConstraints, dcConfigArrayLocal, chassisArrayLocal, actualChassisID, dcItem) {
   // 
   console.log(`dcConfigNumberOfCoresNeededInitial() 5: [chassisID=${actualChassisID},DC=${dcItem}] dcConfigArrayLocal[actualChassisID].numberOfServersNeededAllInstances=${dcConfigArrayLocal[actualChassisID].numberOfServersNeededAllInstances}, dcConfigArrayLocal[dcItem].numberOfNeededMonInstances=${dcConfigArrayLocal[dcItem].numberOfNeededMonInstances}, dcConfigArrayLocal[actualChassisID].numberOfLocalScaleoutInstances=${dcConfigArrayLocal[actualChassisID].numberOfLocalScaleoutInstances}, dcConfigArrayLocal[dcItem].numberOfLocalSpecialInstances=${dcConfigArrayLocal[dcItem].numberOfLocalSpecialInstances} `)
   if (dcConfigArrayLocal[dcItem].numberOfServersNeededAllInstances > 0) {


### PR DESCRIPTION
This is a change towards being able to use debug() function going forward instead of console.log().
#5 and #105 are depending on it.